### PR TITLE
Redis timeseries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - redis
   redis:
-    image: redis:6.2
+    image: redislabs/redistimeseries
     restart: unless-stopped
     command: redis-server --appendonly yes --loglevel warning
     ports:

--- a/src/exts/ajo.py
+++ b/src/exts/ajo.py
@@ -14,11 +14,9 @@ class Ajo(Cog):
         if message.author.bot or message.guild is None:
             return
 
-        # this message is not interesting
         contains_ajo = await self.bot.manager.contains_ajo(message)
-        if not contains_ajo:
-            return
 
+        # Relevant message
         if contains_ajo:
             await self.bot.manager.add_ajo(
                 message.author.id,
@@ -26,9 +24,9 @@ class Ajo(Cog):
                 1
             )
 
-        is_begging = await self.bot.manager.is_begging_for_ajo(message)
-        if is_begging:
-            await message.add_reaction(AJO)
+            is_begging = await self.bot.manager.is_begging_for_ajo(message)
+            if is_begging:
+                await message.add_reaction(AJO)
 
     # AJO/VERAJO
     @command(name="ajo", description="Get your count of ajos.")

--- a/src/exts/ajo.py
+++ b/src/exts/ajo.py
@@ -18,6 +18,12 @@ class Ajo(Cog):
 
         # Relevant message
         if contains_ajo:
+            # 1. Log the message into the timeseries redis
+
+            # Log the guild +1 ajo message
+            self.bot.manager.redis_ts.add(f"ajoseries:{message.guild.id}:{message.author.id}", int(message.created_at.timestamp()), 1, labels={"guild": message.guild.id, "author": message.author.id})
+
+            # 2. Process the message
             await self.bot.manager.add_ajo(
                 message.author.id,
                 f"{message.author.name}#{message.author.discriminator}",

--- a/src/impl/ajo/manager.py
+++ b/src/impl/ajo/manager.py
@@ -29,6 +29,7 @@ LEADERBOARD = "lb"
 class AjoManager:
     def __init__(self) -> None:
         self.redis = redis.Redis(host=environ['REDIS_HOST'])
+        self.redis_ts = redis.Redis(host=environ['REDIS_HOST']).ts()
         logger.info("Connected to the database.")
 
     def __get_seed(self) -> int:


### PR DESCRIPTION
This MR will allow to log messages in a redis timeseries format, such as:

```
1652040081.460486 [0 172.29.0.1:32772] "TS.ADD" "ajoseries:697544527950512168:99266052151599104" "1652040081" "1" "LABELS" "guild" "697544527950512168" "author" "99266052151599104"
1652040071.101233 [0 172.29.0.1:32772] "TS.ADD" "ajoseries:697544527950512168:468516898309537792" "1652040071" "1" "LABELS" "guild" "697544527950512168" "author" "468516898309537792"
```

So later we can do:

```
127.0.0.1:6379> ts.mrange 1622040164 1652040222 aggregation sum 5000 withlabels  filter guild=697544527950512168
1) 1) "ajoseries:697544527950512168:468516898309537792"
   2) 1) 1) "guild"
         2) "697544527950512168"
      2) 1) "author"
         2) "468516898309537792"
   3) 1) 1) (integer) 1652040000
         2) 2
2) 1) "ajoseries:697544527950512168:99266052151599104"
   2) 1) 1) "guild"
         2) "697544527950512168"
      2) 1) "author"
         2) "99266052151599104"
   3) 1) 1) (integer) 1652040000
         2) 1
127.0.0.1:6379> 
```