### PR TITLE
feat: discombobulate events sends a private message to the target

### DIFF
--- a/src/exts/ajo.py
+++ b/src/exts/ajo.py
@@ -78,8 +78,15 @@ class Ajo(Cog):
                         target = self.bot.get_user(int(entry["user_id"]))
                         guild = self.bot.get_guild(int(entry["guild_id"]))
                         discombobulator = self.bot.get_user(int(entry["discombobulator_id"]))
-                        await target.send(f"You have been discombobulated by {discombobulator.name}#{discombobulator.discriminator} from guild "+guild.name)
+                        message = f"You have been discombobulated by {discombobulator.name}#{discombobulator.discriminator} from guild "+guild.name
+                        await target.send(message)
 
+                        # send a private message to the target
+                        target_channel = target.dm_channel()
+                        if target_channel is None:
+                            target_channel = await user.create_dm()
+                        try: 
+                            await target_channel.send(message)
 
         except Exception as e:
             logger.error("There was an exception while running on_ajo task. Retrying.")


### PR DESCRIPTION
As requested, when someone is discombobulated the bot sends a DM to that user. Close #87 